### PR TITLE
feat: allow non dop headers in consumers

### DIFF
--- a/opentelemetry_instrumentation_django_outbox_pattern/utils/formatters.py
+++ b/opentelemetry_instrumentation_django_outbox_pattern/utils/formatters.py
@@ -12,7 +12,7 @@ def format_consumer_destination(headers: typing.Dict) -> str:
     {exchange}:{routing_key}
     """
     destination = headers.get("destination", "")
-    dop_destination = headers.get("dop-msg-destination", "")
+    dop_destination = headers.get("dop-msg-destination", "") or headers.get("tshoot-destination", destination)
     split_destination = dop_destination.split("/")
     routing_key = split_destination[-1]
     exchange = split_destination[-2]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "opentelemetry-instrumentation-django-outbox-pattern"
-version = "0.0.1"
+version = "0.0.2"
 description = "Opentelemetry instrumentor for django-outbox-pattern package"
 authors = ["Juntos Somos Mais <labs@juntossomosmais.com.br>"]
 readme = "README.md"

--- a/tests/utils/test_formatters.py
+++ b/tests/utils/test_formatters.py
@@ -23,6 +23,23 @@ class FormattersTestCase(TestCase):
         result = format_consumer_destination(headers)
         self.assertEqual(result, "test-exchange:test-queue")
 
+    def test_format_consumer_destination_when_tshoot_destination(self):
+        """Test format_consumer_destination when using tshoot-destination"""
+        headers = {
+            "destination": "/queue/test-queue",
+            "tshoot-destination": "/queue/test-queue",
+        }
+        result = format_consumer_destination(headers)
+        self.assertEqual(result, "queue:test-queue")
+
+    def test_format_consumer_destination_when_no_dop_nor_tshoot_destination(self):
+        """Test format_consumer_destination when no dop-msg-destination nor tshoot-destination"""
+        headers = {
+            "destination": "/exchange/test-exchange/test-routing-key",
+        }
+        result = format_consumer_destination(headers)
+        self.assertEqual(result, "test-exchange:test-routing-key")
+
     def test_format_publisher_destination(self):
         """Test format_publisher_destination"""
         destination = "/exchange/test-exchange/test-routing-key"


### PR DESCRIPTION
## Infos

[comment]: <> ([Task name]https://github.com/juntossomosmais/opentelemetry-instrumentation-django-stomp/issues;)

#### What is being delivered?

This pull request updates the `format_consumer_destination` utility function to improve how it selects the destination header, adds new tests to cover these scenarios, and bumps the package version for release.

**Enhancements to destination header handling:**

* Updated `format_consumer_destination` in `utils/formatters.py` to use the `tshoot-destination` header as a fallback when `dop-msg-destination` is missing, defaulting to `destination` if neither is present.

**Expanded test coverage:**

* Added tests in `tests/utils/test_formatters.py` to verify behavior when only `tshoot-destination` is present, and when neither `dop-msg-destination` nor `tshoot-destination` are present.

**Version update:**

* Bumped the package version in `pyproject.toml` from `0.0.1` to `0.0.2` to reflect the new changes.

#### What impacts?

This change allows `django-outbox-pattern` consumer's instrumentation to process messages that does not contains `django-outbox-pattern` headers (like `dop-msg-destination`) or `django-stomp` headers (like `tshoot-destination`).

---
Doubts about the flow?
[Take a look at JS+ gitflow!](https://github.com/juntossomosmais/gitflow/blob/main/gitflow/backend/README.md)
